### PR TITLE
Auth improvements

### DIFF
--- a/auth/auth-contract-test/src/main/java/com/masterello/auth/extension/AuthMockExtension.java
+++ b/auth/auth-contract-test/src/main/java/com/masterello/auth/extension/AuthMockExtension.java
@@ -1,0 +1,69 @@
+package com.masterello.auth.extension;
+
+import com.masterello.auth.data.AuthData;
+import com.masterello.auth.service.AuthService;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+
+public class AuthMockExtension implements BeforeEachCallback, AfterEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        // Get the AuthMocked annotation from the test method
+        AuthMocked authMocked = context.getRequiredTestMethod().getAnnotation(AuthMocked.class);
+
+        if (authMocked != null) {
+
+            // Get the test instance and find the `authService` field
+            Object testInstance = context.getRequiredTestInstance();
+            AuthService authService = getAuthServiceFromTestInstance(testInstance);
+
+            if (authService != null) {
+                // Set up the mock for validateToken using the values from the annotation
+                when(authService.validateToken(Mockito.anyString()))
+                        .thenReturn(Optional.of(AuthData.builder()
+                                .userId(UUID.fromString(authMocked.userId()))
+                                .userRoles(Arrays.asList(authMocked.roles()))
+                                .emailVerified(authMocked.emailVerified())
+                                .build()));
+            } else {
+                throw new IllegalStateException("AuthService mock not found in test instance or parent classes");
+            }
+
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        Object testInstance = context.getRequiredTestInstance();
+        AuthService authService = getAuthServiceFromTestInstance(testInstance);
+        if (authService != null) {
+            Mockito.reset(authService);
+        }
+    }
+
+    // Utility method to get `authService` from the test instance or its superclasses
+    private AuthService getAuthServiceFromTestInstance(Object instance) throws IllegalAccessException {
+        Class<?> currentClass = instance.getClass();
+        while (currentClass != null) {
+            try {
+                Field authServiceField = currentClass.getDeclaredField("authService");
+                authServiceField.setAccessible(true);
+                return (AuthService) authServiceField.get(instance);
+            } catch (NoSuchFieldException e) {
+                currentClass = currentClass.getSuperclass(); // Move to the superclass
+            }
+        }
+        return null;
+    }
+}
+

--- a/auth/auth-contract-test/src/main/java/com/masterello/auth/extension/AuthMocked.java
+++ b/auth/auth-contract-test/src/main/java/com/masterello/auth/extension/AuthMocked.java
@@ -1,0 +1,16 @@
+package com.masterello.auth.extension;
+
+import com.masterello.auth.data.AuthZRole;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMocked {
+    String userId();
+    AuthZRole[] roles() default {AuthZRole.USER};
+
+    boolean emailVerified() default true;
+
+}
+

--- a/category/category-impl/src/main/kotlin/com/masterello/category/configuration/CategorySecurityConfig.kt
+++ b/category/category-impl/src/main/kotlin/com/masterello/category/configuration/CategorySecurityConfig.kt
@@ -1,13 +1,13 @@
 package com.masterello.category.configuration
 
+import com.masterello.auth.service.AuthService
 import com.masterello.commons.security.filter.AuthFilter
-import kotlin.jvm.Throws;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 import org.springframework.security.web.util.matcher.OrRequestMatcher
@@ -15,7 +15,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher
 
 @Configuration
 @EnableWebSecurity
-open class CategorySecurityConfig(private val authFilter: AuthFilter) {
+open class CategorySecurityConfig(private val authService: AuthService) {
 
     @Bean
     @Throws(Exception::class)
@@ -26,6 +26,8 @@ open class CategorySecurityConfig(private val authFilter: AuthFilter) {
                 AntPathRequestMatcher("/api/categories/{id}", "PUT"),
                 AntPathRequestMatcher("/api/categories/{id}/activate", "PUT")
         )
+
+        val authFilter = AuthFilter(protectedEndpoints, authService)
 
         http
                 .securityMatcher(AntPathRequestMatcher("/api/categories/**"))

--- a/commons/common-security/src/main/java/com/masterello/commons/security/exception/UnauthorisedException.java
+++ b/commons/common-security/src/main/java/com/masterello/commons/security/exception/UnauthorisedException.java
@@ -3,7 +3,7 @@ package com.masterello.commons.security.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(value = HttpStatus.UNAUTHORIZED)
+@ResponseStatus(value = HttpStatus.FORBIDDEN)
 public class UnauthorisedException extends RuntimeException {
 
     public UnauthorisedException(String message) {

--- a/commons/common-security/src/main/java/com/masterello/commons/security/filter/AuthFilter.java
+++ b/commons/common-security/src/main/java/com/masterello/commons/security/filter/AuthFilter.java
@@ -1,7 +1,6 @@
 package com.masterello.commons.security.filter;
 
 import com.masterello.auth.service.AuthService;
-import com.masterello.commons.security.data.AnonymousMasterelloAuthentication;
 import com.masterello.commons.security.data.MasterelloAuthentication;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -10,37 +9,47 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.WebUtils;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static com.masterello.auth.config.AuthConstants.M_TOKEN_COOKIE;
 
-@Component
 @RequiredArgsConstructor
 public class AuthFilter extends OncePerRequestFilter {
+    private final RequestMatcher requestMatcher;
     private final AuthService authService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if(!requestMatcher.matches(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         Cookie cookie = WebUtils.getCookie(request, M_TOKEN_COOKIE);
         Authentication auth;
-        if(cookie == null ) {
-            auth = new AnonymousMasterelloAuthentication();
+
+        if (cookie == null) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
         } else {
-            auth = authService.validateToken(cookie.getValue())
-                    .map(MasterelloAuthentication::new)
-                    .map(Authentication.class::cast)
-                    .orElseGet(AnonymousMasterelloAuthentication::new);
+            // Validate token
+            Optional<MasterelloAuthentication> validatedAuth = authService.validateToken(cookie.getValue())
+                    .map(MasterelloAuthentication::new);
+
+            if (validatedAuth.isPresent()) {
+                auth = validatedAuth.get();
+            } else {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("Invalid or expired token");
+                return;
+            }
         }
-
-        SecurityContext securityContext = SecurityContextHolder.getContext();
-        securityContext.setAuthentication(auth);
-
+        SecurityContextHolder.getContext().setAuthentication(auth);
         filterChain.doFilter(request, response);
     }
 }

--- a/commons/common-test/build.gradle
+++ b/commons/common-test/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
+    implementation project(':auth-contract')
+    implementation project(':auth-contract-test')
+
     implementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/commons/common-test/src/main/java/com/masterello/commons/test/AbstractWebIntegrationTest.java
+++ b/commons/common-test/src/main/java/com/masterello/commons/test/AbstractWebIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.masterello.commons.test;
 
+import com.masterello.auth.extension.AuthMockExtension;
+import com.masterello.auth.service.AuthService;
 import io.restassured.RestAssured;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,7 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith({SpringExtension.class, AuthMockExtension.class})
 @AutoConfigureMockMvc
 @ActiveProfiles("integration-test")
 @Slf4j
@@ -24,6 +26,9 @@ public class AbstractWebIntegrationTest extends AbstractDBIntegrationTest{
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private AuthService authService;
 
     @LocalServerPort
     private Integer port;

--- a/file/file-impl/src/main/kotlin/com/masterello/file/configuration/FileSecurityConfig.kt
+++ b/file/file-impl/src/main/kotlin/com/masterello/file/configuration/FileSecurityConfig.kt
@@ -1,7 +1,7 @@
 package com.masterello.file.configuration
 
+import com.masterello.auth.service.AuthService
 import com.masterello.commons.security.filter.AuthFilter
-import kotlin.jvm.Throws
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -10,20 +10,31 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher
+import org.springframework.security.web.util.matcher.OrRequestMatcher
+import org.springframework.security.web.util.matcher.RequestMatcher
 
 @Configuration
 @EnableWebSecurity
-open class FileSecurityConfig(private val authFilter: AuthFilter) {
+open class FileSecurityConfig(private val authService: AuthService) {
 
     @Bean
     @Throws(Exception::class)
     open fun apiFileAuthFilter(http: HttpSecurity): SecurityFilterChain {
+        val publicEndpoints: RequestMatcher = OrRequestMatcher(
+                AntPathRequestMatcher("/api/files/{userUuid}/images"),
+                AntPathRequestMatcher("/api/files/{userUuid}/thumbnails"),
+                AntPathRequestMatcher("/api/files/{userUuid}"),
+                AntPathRequestMatcher("/api/files/bulkSearch"),
+        )
+        val authFilter = AuthFilter(
+                NegatedRequestMatcher(publicEndpoints), authService)
+
         http
             .securityMatcher(AntPathRequestMatcher("/api/files/**"))
             .csrf { it.disable() }
             .authorizeHttpRequests { auth -> auth
-                .requestMatchers("/api/files/{userUuid}/images", "/api/files/{userUuid}/thumbnails",
-                    "/api/files/{userUuid}", "/api/files/bulkSearch").permitAll()
+                .requestMatchers(publicEndpoints).permitAll()
                 .anyRequest().authenticated() }
             .addFilterBefore(authFilter, AnonymousAuthenticationFilter::class.java)
             .sessionManagement { session -> session

--- a/user/user-impl/src/test/java/com/masterello/user/controller/SupportRequestControllerIntegrationTest.java
+++ b/user/user-impl/src/test/java/com/masterello/user/controller/SupportRequestControllerIntegrationTest.java
@@ -1,27 +1,17 @@
 package com.masterello.user.controller;
 
-import com.masterello.auth.data.AuthData;
 import com.masterello.auth.data.AuthZRole;
-import com.masterello.auth.service.AuthService;
+import com.masterello.auth.extension.AuthMocked;
 import com.masterello.commons.test.AbstractWebIntegrationTest;
 import com.masterello.user.UserTestConfiguration;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlGroup;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import static com.masterello.user.util.TestDataProvider.ACCESS_TOKEN;
-import static com.masterello.user.util.TestDataProvider.VERIFIED_USER;
-import static com.masterello.user.util.TestDataProvider.buildSupportRequestDto;
-import static com.masterello.user.util.TestDataProvider.tokenCookie;
+import static com.masterello.user.util.TestDataProvider.*;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.when;
 
 @SqlGroup({
         @Sql(scripts = "classpath:sql/create-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
@@ -30,12 +20,9 @@ import static org.mockito.Mockito.when;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {UserTestConfiguration.class})
 public class SupportRequestControllerIntegrationTest extends AbstractWebIntegrationTest {
 
-    @Autowired
-    private AuthService authService;
-
     @Test
+    @AuthMocked(userId = VERIFIED_USER_S, roles = {AuthZRole.ADMIN})
     public void completeRequest() {
-        mockAuth(VERIFIED_USER, List.of(AuthZRole.ADMIN), true);
         //@formatter:off
         RestAssured
                 .given()
@@ -59,12 +46,13 @@ public class SupportRequestControllerIntegrationTest extends AbstractWebIntegrat
                 .when()
                     .post("/api/support/completeRequest/2d3c2abe-af52-4008-b147-6c816dbaba06")
                 .then()
-                    .statusCode(403);
+                    .statusCode(401);
         //@formatter:on
     }
+
     @Test
-    public void completeRequestUserAuth() {
-        mockAuth(VERIFIED_USER, List.of(AuthZRole.USER), true);
+    @AuthMocked(userId = VERIFIED_USER_S, roles = {AuthZRole.USER})
+    public void completeRequestUserAuth_notOwner() {
         //@formatter:off
         RestAssured
                 .given()
@@ -74,13 +62,13 @@ public class SupportRequestControllerIntegrationTest extends AbstractWebIntegrat
                 .when()
                     .post("/api/support/completeRequest/2d3c2abe-af52-4008-b147-6c816dbaba06")
                 .then()
-                .statusCode(401);
+                .statusCode(403);
         //@formatter:on
     }
 
     @Test
+    @AuthMocked(userId = VERIFIED_USER_S, roles = {AuthZRole.ADMIN})
     public void completeRequestNotFound() {
-        mockAuth(VERIFIED_USER, List.of(AuthZRole.ADMIN), true);
         //@formatter:off
         RestAssured
                 .given()
@@ -112,8 +100,8 @@ public class SupportRequestControllerIntegrationTest extends AbstractWebIntegrat
     }
 
     @Test
+    @AuthMocked(userId = VERIFIED_USER_S, roles = {AuthZRole.ADMIN})
     public void retrieveUnprocessedRequests() {
-        mockAuth(VERIFIED_USER, List.of(AuthZRole.ADMIN), true);
         //@formatter:off
         RestAssured
                 .given()
@@ -135,8 +123,8 @@ public class SupportRequestControllerIntegrationTest extends AbstractWebIntegrat
     }
 
     @Test
-    public void retrieveUnprocessedRequestsUserAuth() {
-        mockAuth(VERIFIED_USER, List.of(AuthZRole.USER), true);
+    @AuthMocked(userId = VERIFIED_USER_S, roles = {AuthZRole.USER})
+    public void retrieveUnprocessedRequestsUserAuth_notAdmin() {
         //@formatter:off
         RestAssured
                 .given()
@@ -146,7 +134,7 @@ public class SupportRequestControllerIntegrationTest extends AbstractWebIntegrat
                 .when()
                     .get("/api/support/getAllUnprocessedRequests")
                 .then()
-                    .statusCode(401);
+                    .statusCode(403);
         //@formatter:on
     }
 
@@ -166,8 +154,8 @@ public class SupportRequestControllerIntegrationTest extends AbstractWebIntegrat
     }
 
     @Test
+    @AuthMocked(userId = VERIFIED_USER_S, roles = {AuthZRole.ADMIN})
     public void retrieveAllSupportRequests() {
-        mockAuth(VERIFIED_USER, List.of(AuthZRole.ADMIN), true);
 
         //@formatter:off
         RestAssured
@@ -184,9 +172,8 @@ public class SupportRequestControllerIntegrationTest extends AbstractWebIntegrat
     }
 
     @Test
-    public void retrieveAllSupportRequestsUserAuth() {
-        mockAuth(VERIFIED_USER, List.of(AuthZRole.USER), true);
-
+    @AuthMocked(userId = VERIFIED_USER_S, roles = {AuthZRole.USER})
+    public void retrieveAllSupportRequestsUserAuth_notAdmin() {
         //@formatter:off
         RestAssured
                 .given()
@@ -196,7 +183,7 @@ public class SupportRequestControllerIntegrationTest extends AbstractWebIntegrat
                 .when()
                     .get("/api/support/getAllRequests")
                 .then()
-                    .statusCode(401);
+                    .statusCode(403);
         //@formatter:on
     }
 
@@ -211,16 +198,7 @@ public class SupportRequestControllerIntegrationTest extends AbstractWebIntegrat
                 .when()
                     .get("/api/support/getAllRequests")
                 .then()
-                    .statusCode(403);
+                    .statusCode(401);
         //@formatter:on
-    }
-
-    private void mockAuth(UUID userId, List<AuthZRole> roles, boolean emailVerified) {
-        when(authService.validateToken(ACCESS_TOKEN))
-                .thenReturn(Optional.of(AuthData.builder()
-                        .userId(userId)
-                        .userRoles(roles)
-                        .emailVerified(emailVerified)
-                        .build()));
     }
 }

--- a/user/user-impl/src/test/java/com/masterello/user/util/TestDataProvider.java
+++ b/user/user-impl/src/test/java/com/masterello/user/util/TestDataProvider.java
@@ -24,8 +24,12 @@ public final class TestDataProvider {
 
     public static final String CLIENT_BEARER = "Basic Z3c6M1RaLCZdL0VyQHRicCZQQmRofDtScHNvY2tQdygo";
 
-    public static final UUID VERIFIED_USER = UUID.fromString("49200ea0-3879-11ee-be56-0242ac120002");
-    public static final UUID VERIFIED_USER_2 = UUID.fromString("ba7bb05a-80b3-41be-8182-66608aba2a31");
+    public static final String VERIFIED_USER_S ="49200ea0-3879-11ee-be56-0242ac120002";
+
+    public static final UUID VERIFIED_USER = UUID.fromString(VERIFIED_USER_S);
+
+    public static final String VERIFIED_USER_2_S = "ba7bb05a-80b3-41be-8182-66608aba2a31";
+    public static final UUID VERIFIED_USER_2 = UUID.fromString(VERIFIED_USER_2_S);
     public static final String VERIFIED_USER_EMAIL = "verified@gmail.com";
     public static final String VERIFIED_USER_PASS = "password";
     public static final UUID NOT_VERIFIED_LINK_EXPIRED_USER = UUID.fromString("e8b0639f-148c-4f74-b834-bbe04072a999");

--- a/worker/worker-impl/src/test/java/com/masterello/worker/util/WorkerTestDataProvider.java
+++ b/worker/worker-impl/src/test/java/com/masterello/worker/util/WorkerTestDataProvider.java
@@ -11,14 +11,20 @@ import static com.masterello.auth.config.AuthConstants.M_TOKEN_COOKIE;
 
 public final class WorkerTestDataProvider {
 
-    public static final UUID USER = UUID.fromString("bb2c6e16-2228-4ac1-8482-1f3548672b43");
-    public static final UUID ADMIN = UUID.fromString("455aee9c-9629-466f-bfc5-8d956da74769");
-    public static final UUID WORKER_1 = UUID.fromString("e5fcf8dd-b6be-4a36-a85a-e2d952cc6254");
-    public static final UUID WORKER_2 = UUID.fromString("e4de38bf-168e-41fc-b7b1-b9d74a47529e");
+    public static final String USER_S = "bb2c6e16-2228-4ac1-8482-1f3548672b43";
+    public static final UUID USER = UUID.fromString(USER_S);
+    public static final String ADMIN_S = "455aee9c-9629-466f-bfc5-8d956da74769";
+    public static final UUID ADMIN = UUID.fromString(ADMIN_S);
+    public static final String WORKER_1_S = "e5fcf8dd-b6be-4a36-a85a-e2d952cc6254";
+    public static final UUID WORKER_1 = UUID.fromString(WORKER_1_S);
+    public static final String WORKER_2_S = "e4de38bf-168e-41fc-b7b1-b9d74a47529e";
+
+    public static final UUID WORKER_2 = UUID.fromString(WORKER_2_S);
     public static final UUID WORKER_3 = UUID.fromString("d1c822c9-0ee4-462a-a88e-7c45e3bb0e54");
     public static final UUID WORKER_4 = UUID.fromString("57bc029c-d8e3-458f-b25a-7f73283cec98");
     public static final UUID WORKER_5 = UUID.fromString("b007b62c-43cf-4ac3-b1e5-36fb9f1c0f52");
-    public static final UUID WORKER_6 = UUID.fromString("8824a15c-98f5-49d9-bd97-43d1cba3f62c");
+    public static final String WORKER_6_S = "8824a15c-98f5-49d9-bd97-43d1cba3f62c";
+    public static final UUID WORKER_6 = UUID.fromString(WORKER_6_S);
 
     public static final String DESCRIPTION = "Best nogotochki in Berlin";
     public static final String WHATSAPP = "whatsap4ik";


### PR DESCRIPTION
* fixed 401 and 403 statuses
  * 401 is returned when user cannot be authenticated (missing or invalid token) 
  * 403 is returned when user is authenticated but lacking permissions

* improved testing. Auth can be mocked with annotation
```
 @Test
    @AuthMocked(userId = USER_ID, roles = {AuthZRole.WORKER})
    void testForAuthenticatedEndpoint() {

    }
 ```